### PR TITLE
chore: enable `platformAutomerge` and set `recreateWhen` to `always

### DIFF
--- a/cgrindel_default.json
+++ b/cgrindel_default.json
@@ -5,5 +5,6 @@
     ":rebaseStalePrs",
     ":automergeAll"
   ],
+  "recreateWhen": "always",
   "platformAutomerge": true
 }

--- a/cgrindel_default.json
+++ b/cgrindel_default.json
@@ -4,5 +4,6 @@
     ":semanticCommits",
     ":rebaseStalePrs",
     ":automergeAll"
-  ]
+  ],
+  "platformAutomerge": true
 }


### PR DESCRIPTION
Renovate will use GitHub's automerge and ensure that automerge is not disabled if a previous PR is found.
