### PR TITLE
chore: try to force recreateClosed

### DIFF
--- a/cgrindel_default.json
+++ b/cgrindel_default.json
@@ -6,5 +6,6 @@
     ":automergeAll"
   ],
   "recreateWhen": "always",
+  "recreateClosed": true,
   "platformAutomerge": true
 }


### PR DESCRIPTION
This should happen with `recreateWhen` equal to `always`. Does not seem to be picked up.
