### PR TITLE
chore: remove `recreateClosed`

### DIFF
--- a/cgrindel_default.json
+++ b/cgrindel_default.json
@@ -6,6 +6,5 @@
     ":automergeAll"
   ],
   "recreateWhen": "always",
-  "recreateClosed": true,
   "platformAutomerge": true
 }


### PR DESCRIPTION
Trying to force `recreateClosed`, a legacy config value, did not work.